### PR TITLE
Use getAttribute instead of tabindex for consistent browser behavior

### DIFF
--- a/src/focus.service.ts
+++ b/src/focus.service.ts
@@ -570,7 +570,9 @@ export class FocusService {
    * Returns if the element can receive focus.
    */
   private isFocusable(el: HTMLElement): boolean {
-    if (el.tabIndex < 0) {
+    //Dev note: el.tabindex is not consistent across browsers
+    const tabIndex = el.getAttribute('tabIndex');
+    if (!tabIndex || +tabIndex < 0) {
       return false;
     }
 


### PR DESCRIPTION
if Element has no tabindex defined, `el.tabindex` returns `null` in chrome whereas it returns `0` in Edge leading to focusByRaycast returning un-focusable elements.