### PR TITLE
DOM events to intercept arcade machine focus

### DIFF
--- a/src/focus.service.ts
+++ b/src/focus.service.ts
@@ -270,7 +270,7 @@ export class FocusService {
     this.focusRoot = newRootElem;
   }
 
-  public releaseFocus(releaseElem?: HTMLElement, scrollSpeed: number = Infinity) {
+  public releaseFocus(releaseElem?: HTMLElement, scrollSpeed: number = this.scrollSpeed) {
     if (releaseElem) {
       if (releaseElem === this.focusRoot) {
         this.releaseFocus(null, scrollSpeed);
@@ -299,7 +299,7 @@ export class FocusService {
   /**
    * Sets the root element to use for focusing.
    */
-  public setRoot(root: HTMLElement, scrollSpeed: number) {
+  public setRoot(root: HTMLElement, scrollSpeed: number = this.scrollSpeed) {
     if (this.registrySubscription) {
       this.registrySubscription.unsubscribe();
     }
@@ -327,14 +327,14 @@ export class FocusService {
    * this is handle adjustments if the user interacts with other input
    * devices, or if other application logic requests focus.
    */
-  public onFocusChange(focus: HTMLElement, scrollSpeed: number) {
+  public onFocusChange(focus: HTMLElement, scrollSpeed: number = this.scrollSpeed) {
     this.selectNode(focus, scrollSpeed);
   }
 
   /**
    * Wrapper around moveFocus to dispatch arcselectingnode event
    */
-  public selectNode(next: HTMLElement, scrollSpeed: number = null) {
+  public selectNode(next: HTMLElement, scrollSpeed: number = this.scrollSpeed) {
     const canceled = !next.dispatchEvent(new Event('arcselectingnode', { bubbles: true, cancelable: true }));
     if (canceled) {
       return;
@@ -347,7 +347,7 @@ export class FocusService {
    * This is useful when you do not want to dispatch another event
    * e.g. when intercepting and transfering focus
    */
-  public selectNodeWithoutEvent(next: HTMLElement, scrollSpeed: number = null) {
+  public selectNodeWithoutEvent(next: HTMLElement, scrollSpeed: number = this.scrollSpeed) {
     const { selected } = this;
     if (selected === next) {
       return;
@@ -457,7 +457,7 @@ export class FocusService {
     return false;
   }
 
-  public defaultFires(ev: ArcEvent, scrollSpeed: number = Infinity): boolean {
+  public defaultFires(ev: ArcEvent, scrollSpeed: number = this.scrollSpeed): boolean {
     if (ev.defaultPrevented) {
       return true;
     }
@@ -635,7 +635,7 @@ export class FocusService {
   /**
    * Reset the focus if arcade-machine wanders out of root
    */
-  private setDefaultFocus(scrollSpeed: number) {
+  private setDefaultFocus(scrollSpeed: number = this.scrollSpeed) {
     const { selected } = this;
     const focusableElems = this.focusRoot.querySelectorAll('*');
     for (let i = 0; i < focusableElems.length; i += 1) {

--- a/src/focus.service.ts
+++ b/src/focus.service.ts
@@ -326,9 +326,22 @@ export class FocusService {
   }
 
   /**
-   * Updates the selected DOM node.
+   * Wrapper around moveFocus to dispatch arcselectingnode event
    */
-  public selectNode(next: HTMLElement, scrollSpeed: number) {
+  public selectNode(next: HTMLElement, scrollSpeed: number = null) {
+    const canceled = !next.dispatchEvent(new Event('arcselectingnode', { bubbles: true, cancelable: true }));
+    if (canceled) {
+      return;
+    }
+    this.selectNodeWithoutEvent(next, scrollSpeed);
+  }
+
+  /**
+   * Updates the selected DOM node.
+   * This is useful when you do not want to dispatch another event
+   * e.g. when intercepting and transfering focus
+   */
+  public selectNodeWithoutEvent(next: HTMLElement, scrollSpeed: number = null) {
     const { selected } = this;
     if (selected === next) {
       return;
@@ -360,10 +373,14 @@ export class FocusService {
     }
 
     this.switchFocusClass(this.selected, next, this.focusedClass);
-    next.focus();
     this.selected = next;
     this.referenceRect = next.getBoundingClientRect();
     this.rescroll(next, scrollSpeed, this.root);
+
+    const canceled = !next.dispatchEvent(new Event('arcfocuschanging', { bubbles: true, cancelable: true }));
+    if (!canceled) {
+      next.focus();
+    }
   }
 
   private switchFocusClass(prevElem: HTMLElement, nextElem: HTMLElement, className: string) {


### PR DESCRIPTION
Added events around SelectNode that can be intercepted to modify focus behavior.
- `arcfocuschanging` can be intercepted to complete smooth scroll before triggering native focus. This will prevent browser from rescrolling the page to bring element in view.
- `arcselectingnode` can be intercepted to redirect focus to another element
