### PR TITLE
chore(npm): use node v8 and npm 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arcade-machine",
-  "version": "0.12.3",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -72,6 +72,7 @@
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-4.2.6.tgz",
       "integrity": "sha1-ppGdm2HEX/wV++5ZM5jj/VMtq0Y=",
+      "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
@@ -98,9 +99,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.80",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.80.tgz",
-      "integrity": "sha512-FJedmtuVj9Jb2AbI3cKYlAczj+3Lv3I8g2wjricLSRBCW0Oj7kzG4D6gUmgDc2Ptm0A1lat2AuheqK5kdYfswg==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.16.tgz",
+      "integrity": "sha512-P2XfbkmcAnP/XT5J5m59cQPbcIbszCwXRdngnBZefmqt1RgOv4RIFoIkG85QFDHWIt1T6bXogZP/tvh2dm/xEQ==",
       "dev": true
     },
     "@types/winrt-uwp": {
@@ -2509,7 +2510,7 @@
         "on-finished": "2.3.0",
         "parseurl": "1.3.1",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.4",
+        "proxy-addr": "1.1.5",
         "qs": "6.4.0",
         "range-parser": "1.2.0",
         "send": "0.15.3",
@@ -4592,9 +4593,9 @@
       }
     },
     "gulp-typescript": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.2.0.tgz",
-      "integrity": "sha1-jd975ljRMBiDgfZablgMVStkwZY=",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.2.1.tgz",
+      "integrity": "sha1-Us136caETjuai93YjohM60al23k=",
       "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
@@ -5475,9 +5476,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz",
-      "integrity": "sha1-HgOlL9rYOou7KyXL9JmLTP/NPew=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
+      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
       "dev": true
     },
     "is-absolute": {
@@ -5626,6 +5627,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
@@ -6555,6 +6565,12 @@
           "dev": true
         }
       }
+    },
+    "loglevel": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.1.tgz",
+      "integrity": "sha1-lbOD+Ro8J1b9SrCTZn5DCRYfK80=",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -7642,13 +7658,13 @@
       "dev": true
     },
     "proxy-addr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
-      "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
+      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
       "dev": true,
       "requires": {
         "forwarded": "0.1.0",
-        "ipaddr.js": "1.3.0"
+        "ipaddr.js": "1.4.0"
       }
     },
     "prr": {
@@ -8652,9 +8668,9 @@
       }
     },
     "sockjs-client": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.2.tgz",
-      "integrity": "sha1-8CEqhVDkyUaMjM6u79LjSTwDOtU=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+      "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
       "dev": true,
       "requires": {
         "debug": "2.6.8",
@@ -8920,6 +8936,17 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
     "string.prototype.padend": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
@@ -8998,9 +9025,9 @@
       "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
     },
     "systemjs": {
-      "version": "0.20.15",
-      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.20.15.tgz",
-      "integrity": "sha512-3OPiRmVUujzapJqtKb8iC/nG6lkIWnF08tfub9LSjG2aihBJ7wY1gBfEKWq+wRPCp0ltBH/HScASGPv+D4kaDw==",
+      "version": "0.20.17",
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.20.17.tgz",
+      "integrity": "sha512-AK1DBQvn+TaHWPLjZxXE81Y9VCzhu9grs7z/wKYoYp8qV+voasqmjHxZRuK9ZnoJGtrLlLqMcCBjyqErRchWIA==",
       "dev": true
     },
     "tapable": {
@@ -9324,9 +9351,9 @@
       }
     },
     "typescript": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
-      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
       "dev": true
     },
     "uglify-js": {
@@ -9993,9 +10020,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.5.1.tgz",
-      "integrity": "sha1-oC5yaoe7YD211xq7fW0mSb8Qx2k=",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.6.1.tgz",
+      "integrity": "sha1-Cykqnaltr4CmWYj2n4e0Fm5d7+c=",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
@@ -10008,12 +10035,13 @@
         "html-entities": "1.2.1",
         "http-proxy-middleware": "0.17.4",
         "internal-ip": "1.2.0",
+        "loglevel": "1.4.1",
         "opn": "4.0.2",
         "portfinder": "1.0.13",
         "selfsigned": "1.9.1",
         "serve-index": "1.9.0",
         "sockjs": "0.3.18",
-        "sockjs-client": "1.1.2",
+        "sockjs-client": "1.1.4",
         "spdy": "3.4.7",
         "strip-ansi": "3.0.1",
         "supports-color": "3.2.3",
@@ -10036,26 +10064,6 @@
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1",
             "wrap-ansi": "2.1.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
           }
         },
         "supports-color": {
@@ -10284,9 +10292,9 @@
       }
     },
     "zone.js": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.12.tgz",
-      "integrity": "sha1-hv9QU8mK7CkaC/S7rFAdaUoFz7s=",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.14.tgz",
+      "integrity": "sha1-DE2ySxeCMidMy0P3jJnbfzZCts8=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "gulp": "gulp",
     "build": "gulp build",
     "ngc": "cd staging && ngc",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "clean": "rimraf node_modules doc dist && npm cache clean",
     "test:lint": "tslint -t verbose --project tsconfig.json \"src/**/*.ts\"",
     "test:unit": "gulp test",
@@ -20,6 +20,10 @@
     "type": "git",
     "url": "git://github.com/mixer/arcade-machine.git"
   },
+  "engines": {
+    "node": ">=8.2.1",
+    "npm": ">=5.3.0"
+  },
   "dependencies": {
     "@angular/core": "^4.2.0",
     "rxjs": "~5.0.3",
@@ -33,9 +37,8 @@
     "@angular/platform-browser": "^4.2.0",
     "@angular/platform-browser-dynamic": "^4.2.0",
     "@angular/router": "^4.2.0",
-    "@types/core-js": "^0.9.34",
     "@types/jasmine": "^2.5.35",
-    "@types/node": "^6.0.45",
+    "@types/node": "^8.0.16",
     "@types/winrt-uwp": "0.0.16",
     "awesome-typescript-loader": "^3.0.3",
     "clean-webpack-plugin": "^0.1.10",
@@ -44,7 +47,7 @@
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",
     "gulp-concat": "^2.6.0",
-    "gulp-typescript": "^3.0.1",
+    "gulp-typescript": "^3.2.1",
     "html-webpack-plugin": "^2.22.0",
     "jasmine-core": "^2.5.2",
     "karma": "^1.1.1",
@@ -60,13 +63,13 @@
     "npm-run-all": "^4.0.0",
     "rimraf": "^2.5.1",
     "run-sequence": "^1.2.2",
-    "systemjs": "^0.20.11",
+    "systemjs": "^0.20.17",
     "ts-helpers": "^1.1.1",
     "tslint": "^5.5.0",
     "tslint-microsoft-contrib": "^5.0.1",
-    "typescript": "^2.4.1",
+    "typescript": "^2.4.2",
     "webpack": "^2.2.1",
-    "webpack-dev-server": "^2.3.0",
-    "zone.js": "^0.8.5"
+    "webpack-dev-server": "^2.6.1",
+    "zone.js": "^0.8.14"
   }
 }


### PR DESCRIPTION
@saadataz tests here are not functional at all, (the warnings from the node v8 typings are irrelevant).

Maybe we should use the testing setup used in frontend2, at least that works. @UnwrittenFun @RobertGoins if you have any time that'd be great!