### PR TITLE
Introducing Arc-Focus-Inside

### DIFF
--- a/demo/src/bundles/demo/page1.component.ts
+++ b/demo/src/bundles/demo/page1.component.ts
@@ -120,6 +120,19 @@ import { Observable } from 'rxjs/Observable';
       </div>
     </div>
 
+    <h1>Focus Inside</h1>
+    Transfer focus to elements inside me
+    <div class="area" tabindex="0" arc arc-focus-inside="true" style="display: flex; align-items: center;">
+      <div class="box" arc tabindex="0" style="display: inline-block; margin-left:50px; width:50px; height:50px">Short</div>
+      <div id="focus-inside1" class="area" arc arc-focus-inside="true" tabindex="0" style="display: inline-block; margin:50px;">
+        me too
+        <div class="box" arc tabindex="0" style="margin-left:50px; width:50px; height:50px">Short</div>
+        <div class="box" arc tabindex="0" style="margin-left:150px; width:50px; height:50px">Short</div>
+        <div class="box" arc tabindex="0" style="margin-left:250px; width:50px; height:50px">Short</div>
+      </div>
+      <div class="box" arc tabindex="0" style="display: inline-block; margin-left:50px; width:50px; height:50px">Short</div>
+    </div>
+
     <h1>Non-Overlapping Elements</h1>
     <div class="area">
       <div class="box-wrapper" *ngFor="let box of boxes.slice(0, 3); let i = index"
@@ -136,10 +149,10 @@ import { Observable } from 'rxjs/Observable';
     <h1>A Form</h1>
     <div class="area">
       <form>
-        <div><input placeholder="Username"></div>
-        <div><input placeholder="Password" type="password"></div>
-        <div><textarea></textarea></div>
-        <div><button>Submit</button></div>
+        <div><input tabindex="0" placeholder="Username"></div>
+        <div><input tabindex="0" placeholder="Password" type="password"></div>
+        <div><textarea tabindex="0"></textarea></div>
+        <div><button tabindex="0">Submit</button></div>
       </form>
     </div>
 

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,18 @@ It can also be used with *ngFor. For instance, following will focus the 3rd elem
   arc [arc-default-focus]="i === 2">
 </div>
 ```
+
+##### arc-focus-inside
+
+If arc-focus-inside is present on a focusable element; on focus, it transfers the focus to its next best child element.
+This is particularly useful to make elements focusable that are not directly in the focus direction.
+
+```html
+<div tabindex="0" arc arc-focus-inside="true">
+  <div tabindex="0">I will be focused instead</div>
+</div>
+```
+
 ##### (arc-capture-outgoing)="onEvent(IArcEvent)"
 
 `arc-capture-outgoing` can be set to handle, and possibly cancel, events sent while the element or one of its children are focused. See the `IArcEvent` type for more details:

--- a/src/arc.directive.ts
+++ b/src/arc.directive.ts
@@ -64,6 +64,9 @@ export class ArcDirective implements OnInit, OnDestroy, IArcHandler {
     this.innerExcludeThis = exclude !== false;
   }
 
+  @Input('arc-focus-inside')
+  public arcFocusInside: boolean;
+
   // Directional/event shortcuts: =============================================
 
   @Output('arc-submit')

--- a/src/model.ts
+++ b/src/model.ts
@@ -96,4 +96,9 @@ export interface IArcHandler {
   arcFocusRight: HTMLElement | string;
   arcFocusUp: HTMLElement | string;
   arcFocusDown: HTMLElement | string;
+
+  /**
+   * If focused, the element transfers focus to its children if true
+   */
+  arcFocusInside: boolean;
 }


### PR DESCRIPTION
This is useful when you want to automatically transfer focus from a bigger container to its child elements. 

#### Typical Use Case:
- Transferring focus from a video container to its controls.
