### PR TITLE
Merge tag 2.0.3 to master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arcade-machine",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcade-machine",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "scripts": {
     "gulp": "gulp",
     "build": "gulp build",


### PR DESCRIPTION
When publish tag 2.0.3, publishing to master failed. I need to merge the tag commit to master. 